### PR TITLE
Ubuntu 18.04 shell support

### DIFF
--- a/client-react/package.json
+++ b/client-react/package.json
@@ -19,7 +19,7 @@
     "slug": "0.9.1"
   },
   "scripts": {
-    "start": "if [ -x ../.env ]; then source ../.env; fi; BROWSER=none PORT=$CLIENT_PORT react-scripts start",
+    "start": "if [ -x ../.env ]; then . ../.env; fi; BROWSER=none PORT=$CLIENT_PORT react-scripts start",
     "build": "react-scripts build",
     "test": "react-scripts test --env=jsdom",
     "eject": "react-scripts eject"


### PR DESCRIPTION
Ubuntu 18.04 defaults to the dash shell, which doesn't include `source`.