### PR TITLE
chore: replace deprecated String.prototype.substr()

### DIFF
--- a/server-koa2/middleware/index.js
+++ b/server-koa2/middleware/index.js
@@ -4,7 +4,7 @@ const middlewares = fs
   .readdirSync(__dirname)
   .filter(fn => fn !== "index.js")
   .filter(fn => fn.match(/^[^.].*\.js$/))
-  .map(str => str.substr(0, str.length - 3));
+  .map(str => str.slice(0, -3));
 
 middlewares.forEach(name => {
   // eslint-disable-next-line import/no-dynamic-require


### PR DESCRIPTION
## Description

[String.prototype.substr()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substr) is deprecated so we replace it with [String.prototype.slice()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/slice) which works similarily but isn't deprecated.
.substr() probably isn't going away anytime soon but the change is trivial so it doesn't hurt to do it.

## Performance impact

From past experience there is no performance impact due to switching to slice()

## Security impact

None as the returned values are still the same

## Checklist

- [x] My code matches the project's code style and `yarn lint:fix` passes.
- [ ] I've added tests for the new feature, and `yarn test` passes.
- [ ] I have detailed the new feature in the relevant documentation.
- [ ] I have added this feature to 'Pending' in the `RELEASE_NOTES.md` file (if one exists).
- [ ] If this is a breaking change I've explained why.

